### PR TITLE
added block sketch of power supply size

### DIFF
--- a/Parts/Power-Supply.scad
+++ b/Parts/Power-Supply.scad
@@ -1,0 +1,18 @@
+POWER_SUPPLY_LENGTH=150;
+POWER_SUPPLY_WIDTH=85;
+POWER_SUPPLY_HEIGHT=40;
+POWER_SUPPLY_CABLE_SLACK=50;
+module power_supply() {
+    color("blue"){
+		cube([POWER_SUPPLY_LENGTH, POWER_SUPPLY_WIDTH, POWER_SUPPLY_HEIGHT]);
+	}
+	power_supply_cable_slack();
+}
+
+module power_supply_cable_slack() {
+	color("red"){
+		translate([POWER_SUPPLY_LENGTH, 0, 0])
+			cube([POWER_SUPPLY_CABLE_SLACK, POWER_SUPPLY_WIDTH, POWER_SUPPLY_HEIGHT]);
+	}
+}
+power_supply();

--- a/printer.scad
+++ b/printer.scad
@@ -2,6 +2,7 @@
 use <Parts/Makerbeam.scad>;
 use <Parts/L-Bracket.scad>;
 use <Parts/Bearing-Mount.scad>;
+use <Parts/Power-Supply.scad>;
 
 module side_brackets() {
     // bottom right
@@ -85,5 +86,7 @@ module printer() {
 	rotate([0, 180, 0])
 		translate([-110, -35, -310])
 			bearing_mount_with_bearing();
+	translate([10, -95, 0])
+		power_supply();
 }
 printer();


### PR DESCRIPTION
If you preview the printer.scad you will see the power supply.

The red section is not physical body of the supply just an area of space needed for the cables coming out of the supply to flex.